### PR TITLE
Reimplement `Maybe` monad wihtout `RightBiased` and `LeftBiased`

### DIFF
--- a/spec/monads/just_spec.cr
+++ b/spec/monads/just_spec.cr
@@ -49,7 +49,7 @@ describe Monads::Just do
   describe "#or" do
     it "result himself" do
       monad = Monads::Just.new(1)
-      exclude = Monads::Success.new("Foo")
+      exclude = Monads::Just.new(3)
       monad.or(exclude).should eq(monad)
     end
   end
@@ -57,12 +57,12 @@ describe Monads::Just do
   describe "#bind" do
     it "export value (block)" do
       monad = Monads::Just.new(1)
-      monad.bind { |value| value + 1 }.should eq(2)
+      monad.bind { |value| Monads::Just.new(value + 1) }.should eq(Monads::Just.new(2))
     end
 
     it "export value (proc)" do
       monad = Monads::Just.new(1)
-      monad.bind(->(value : Int32){ value + 1 }).should eq(2)
+      monad.bind(&->(value : Int32){ Monads::Just.new(value + 1) }).should eq(Monads::Just.new(2))
     end
   end
 
@@ -73,16 +73,10 @@ describe Monads::Just do
     end
   end
 
-  describe "#tee" do
-    it "result himself" do
-      monad = Monads::Just.new(1)
-      monad.tee { |value| value + 1}.should eq(monad)
-    end
-
-    it "value is forwarded" do
-      expectation = 0
-      Monads::Just.new(1).tee { |value| expectation = value }
-      expectation.should eq(1)
+  describe "#map_or" do
+    it "apply function in the case of Just" do
+      monad = Monads::Just.new(2).map_or(-1) { |value| value + 1 }
+      monad.should eq(3)
     end
   end
 

--- a/spec/monads/nothing_spec.cr
+++ b/spec/monads/nothing_spec.cr
@@ -27,14 +27,6 @@ describe Monads::Nothing do
     end
   end
 
-  describe "#value!" do
-    it "get correct value" do
-      expect_raises(Monads::UnwrapError) do
-        Monads::Nothing(Int32).new.value!
-      end
-    end
-  end
-
   describe "#value_or" do
     it "export value (unit)" do
       monad = Monads::Nothing(Int32).new
@@ -56,34 +48,28 @@ describe Monads::Nothing do
   end
 
   describe "#bind" do
-    # it "export value (block)" do
-    #   monad = Monads::None::Instance
-    #   monad.bind { |value| value + 1 }.should eq(monad)
-    # end
-    #
-    # it "export value (proc)" do
-    #   monad = Monads::None::Instance
-    #   monad.bind(->(value : Int32){ value + 1 }).should eq(monad)
-    # end
+    it "export value (block)" do
+      monad = Monads::Nothing(Int32).new
+      monad.bind { |value| Monads::Maybe.return(value + 1) }.should eq(monad)
+    end
+    
+    it "export value (proc)" do
+      monad = Monads::Nothing(Int32).new
+      monad.bind(&->(value : Int32){ Monads::Maybe.return(value + 1) }).should eq(monad)
+    end
   end
 
   describe "#fmap" do
-    # it "not increase by one" do
-    #   monad = Monads::None::Instance.fmap { |value| value + 1 }
-    #   monad.should eq(Monads::None::Instance)
-    # end
+    it "not increase by one" do
+      monad = Monads::Nothing(String).new.fmap { |value| value + "added" }
+      monad.should eq(Monads::Nothing(String).new)
+    end
   end
 
-  describe "#tee" do
-    it "result himself" do
-      # monad = Monads::None::Instance
-      # monad.tee { |value| value + 1}.should eq(monad)
-    end
-
-    it "value is not forwarded" do
-      # expectation = 0
-      # Monads::None::Instance.tee { |value| expectation = value }
-      # expectation.should eq(0)
+  describe "#map_or" do
+    it "return default value in the case of Nothign" do
+      monad = Monads::Nothing(Int32).new.map_or(-1) { |value| value + 1 }
+      monad.should eq(-1)
     end
   end
 

--- a/spec/monads_spec.cr
+++ b/spec/monads_spec.cr
@@ -1,8 +1,8 @@
 require "./spec_helper"
-# require "./monads/**"
+require "./monads/**"
 
 describe Monads do
   it "should have version" do
-    Monads::VERSION.should eq("0.1.0")
+    Monads::VERSION.should eq("0.2.0")
   end
 end

--- a/src/monads/functor.cr
+++ b/src/monads/functor.cr
@@ -1,0 +1,6 @@
+module Monads
+  module Functor(T)
+    abstract def fmap(&block : T -> U) : Functor(U)
+  end
+end
+

--- a/src/monads/maybe.cr
+++ b/src/monads/maybe.cr
@@ -1,6 +1,9 @@
+require "./monad"
+
 module Monads
   abstract class Maybe(T)
     include Comparable(Maybe)
+    include Monads::Monad(T)
 
     def just?
       typeof(self) == Just(T)
@@ -10,24 +13,27 @@ module Monads
       !just?
     end
 
-    abstract def value!
-    abstract def value_or(element : U) forall U
-    abstract def value_or(&block : -> U) forall U
-    abstract def or(monad : Result)
-
-    abstract def bind(&block : T -> U) forall U
-    abstract def bind(lambda : T -> U) forall U
-    abstract def fmap(&block : T -> U) forall U
-    abstract def tee(&block : T -> U) forall U
+    def self.return(v : T)
+      Just.new(v)
+    end
 
     abstract def <=>(other : Maybe(T))
+    abstract def to_s
+    abstract def inspect(io)
+    abstract def or(default : Maybe(T)) : Maybe(T)
+    abstract def value_or(default : T) : T
+    abstract def value_or(&block : -> T) : T
+    abstract def map_or(default : U, &block : T -> U) : U forall U
   end
 
   class Just(T) < Maybe(T)
-    include Monads::RightBiased(T)
     include Comparable(Just)
 
     def initialize(@data : T)
+    end
+
+    def value!
+      @data
     end
 
     def fmap(&block : T -> U) : Just(U) forall U
@@ -43,13 +49,36 @@ module Monads
     end
 
     def <=>(other : Maybe(T))
-      typeof(other) == typeof(self) ? value! <=> other.value! : nil
+      case other
+      when Just(T)
+        value! <=> other.value!
+      else
+        nil
+      end
+    end
+
+    def bind(&block : T -> Maybe(U)) : Maybe(U) forall U
+      block.call(value!)
+    end
+
+    def value_or(default : T) : T
+      value!
+    end
+
+    def value_or(&block : -> T) : T
+      value!
+    end
+
+    def or(default : Maybe(T)) : Maybe(T)
+      Just.new(value!)
+    end
+
+    def map_or(default : U, &block : T -> U) : U forall U
+      block.call(value!)
     end
   end
 
   class Nothing(T) < Maybe(T)
-    include Monads::LeftBiased(Nil)
-
     def fmap(&block : T -> U) : Nothing(U) forall U
       Nothing(U).new
     end
@@ -64,6 +93,26 @@ module Monads
 
     def <=>(other : Maybe(T))
       return typeof(self) == typeof(other) ? 0 : nil
+    end
+
+    def bind(&block : T -> Maybe(U)) : Maybe(U) forall U
+      Nothing(U).new
+    end
+
+    def value_or(default : T) : T
+      default
+    end
+
+    def value_or(&block : -> T) : T
+      block.call
+    end
+
+    def or(default : Maybe(T)) : Maybe(T)
+      default
+    end
+
+    def map_or(default : U, &block : T -> U) : U forall U
+      default
     end
   end
 end

--- a/src/monads/monad.cr
+++ b/src/monads/monad.cr
@@ -1,0 +1,14 @@
+require "./functor"
+
+module Monads
+  module Monad(T)
+    include Monads::Functor(T)
+
+    def self.return(v : T) : self
+      raise NotImplementedError.new("implement `#{Monad(T)}::return` method")
+    end
+
+    abstract def bind(&block : T -> Monad(U)) : Monad(U) forall U
+  end
+end
+


### PR DESCRIPTION
- reimplement these methods:
  * `#or(a)`: if `self` is `Just`, return `self`. but `self` is `Nothing`, return `Just.new(a)`
    * ex `Monads::Maybe.return(1).or(Monads::Maybe.return(2)) == Monads::Maybe.return(1)`
  * `#value_or(a)`: if `self` is `Just`, return `Just#value!`. `self` is `Nothing`, return `a`
    * ex: `Monads::Maybe.return(1).value_or(4) == 1`

- add following method:
  * `#map_or(a, &block)`: if `self` is `Just`, return `Just#value!` applied `&block`. `self` is `Nothing`, return `a`
    * ex: `Monads::Maybe.return(3).map_or(1) {|x| x + 1} == 4`

- add `Monad(T)` and `Functor(T)` and Module. `Maybe` implements these modules.

-  replace these methods:
    * `#fmap`
      * ex: `Monads::Maybe.return(1).fmap {|x| x * 2} == Monads::Maybe.return(2)`
    * `#bind`
      * ex: `Monads::Maybe.return(1).bind {|x| Monads::Maybe.return(x.to_s)} == Monads::Maybe.return("1")`