### PR TITLE
Fix/monad comparable

### DIFF
--- a/spec/monads/either/left_sepc.cr
+++ b/spec/monads/either/left_sepc.cr
@@ -110,9 +110,9 @@ describe Monads::Left do
       boolean.should be_falsey
     end
 
-    it "comparing different type by '#<' should be invalid" do
+    it "comparing different type by '#<' should be valid" do
       boolean = Monads::Left.new(1) < Monads::Right.new(1)
-      boolean.should be_falsey
+      boolean.should be_truthy
     end
   end
 
@@ -132,9 +132,9 @@ describe Monads::Left do
       boolean.should be_falsey
     end
 
-    it "comparing different type by '#<=' should be invalid" do
+    it "comparing different type by '#<=' should be valid" do
       boolean = Monads::Left.new(1) <= Monads::Right.new(1)
-      boolean.should be_falsey
+      boolean.should be_truthy
     end
   end
 

--- a/spec/monads/either/right_spec.cr
+++ b/spec/monads/either/right_spec.cr
@@ -155,9 +155,9 @@ describe Monads::Right do
       boolean.should be_truthy
     end
 
-    it "comparing different type by '#>' should be invalid" do
+    it "comparing different type by '#>' should be valid" do
       boolean = Monads::Right.new(1) > Monads::Left.new(1)
-      boolean.should be_falsey
+      boolean.should be_truthy
     end
   end
 
@@ -177,9 +177,9 @@ describe Monads::Right do
       boolean.should be_truthy
     end
 
-    it "comparing different type by '#>=' should be invalid" do
+    it "comparing different type by '#>=' should be valid" do
       boolean = Monads::Right.new(1) >= Monads::Left.new(1)
-      boolean.should be_falsey
+      boolean.should be_truthy
     end
   end
 

--- a/spec/monads/maybe/nothing_spec.cr
+++ b/spec/monads/maybe/nothing_spec.cr
@@ -52,7 +52,7 @@ describe Monads::Nothing do
       monad = Monads::Nothing(Int32).new
       monad.bind { |value| Monads::Maybe.return(value + 1) }.should eq(monad)
     end
-    
+
     it "export value (proc)" do
       monad = Monads::Nothing(Int32).new
       monad.bind(&->(value : Int32){ Monads::Maybe.return(value + 1) }).should eq(monad)
@@ -86,11 +86,11 @@ describe Monads::Nothing do
       comp.should eq(0)
     end
 
-    it "'Nothing <=> Just' or 'Just <=> Nothing' always return 'nil'" do
+    it "'Nothing <=> Just' or 'Just <=> Nothing' always return number" do
       comp = Monads::Nothing(Int32).new <=> Monads::Just.new(1)
-      comp.should be_nil
+      comp.should eq(-1)
       comp = Monads::Just.new(1) <=> Monads::Nothing(Int32).new
-      comp.should be_nil
+      comp.should eq(1)
     end
   end
 
@@ -99,7 +99,7 @@ describe Monads::Nothing do
       boolean = Monads::Just.new(1) < Monads::Nothing(Int32).new
       boolean.should be_falsey
       boolean = Monads::Nothing(Char).new < Monads::Just.new('a')
-      boolean.should be_falsey
+      boolean.should be_truthy
     end
 
     it "comparison of same type is invalid" do
@@ -111,7 +111,7 @@ describe Monads::Nothing do
   describe "#>" do
     it "comparison of Just is always invalid" do
       boolean = Monads::Just.new(1) > Monads::Nothing(Int32).new
-      boolean.should be_falsey
+      boolean.should be_truthy
       boolean = Monads::Nothing(Char).new > Monads::Just.new('a')
       boolean.should be_falsey
     end
@@ -127,7 +127,7 @@ describe Monads::Nothing do
       boolean = Monads::Just.new(1) <= Monads::Nothing(Int32).new
       boolean.should be_falsey
       boolean = Monads::Nothing(Char).new <= Monads::Just.new('a')
-      boolean.should be_falsey
+      boolean.should be_truthy
     end
 
     it "comparison of same type is valid" do
@@ -139,7 +139,7 @@ describe Monads::Nothing do
   describe "#>=" do
     it "comparison of Just is always invalid" do
       boolean = Monads::Just.new(1) >= Monads::Nothing(Int32).new
-      boolean.should be_falsey
+      boolean.should be_truthy
       boolean = Monads::Nothing(Char).new >= Monads::Just.new('a')
       boolean.should be_falsey
     end

--- a/src/monads/either.cr
+++ b/src/monads/either.cr
@@ -45,11 +45,12 @@ module Monads
       Right.new(block.call(@data))
     end
 
-    def <=>(other : Either)
-      case other
-      when Right(T)
-        value! <=> other.value!
-      end
+    def <=>(other : Right)
+      value! <=> other.value!
+    end
+
+    def <=>(other : Left)
+      1
     end
   end
 
@@ -63,11 +64,12 @@ module Monads
       self
     end
 
-    def <=>(other : Either)
-      case other
-      when Left(E)
-        value! <=> other.value!
-      end
+    def <=>(other : Left)
+      value! <=> other.value!
+    end
+
+    def <=>(other : Right)
+      -1
     end
   end
 end

--- a/src/monads/maybe.cr
+++ b/src/monads/maybe.cr
@@ -51,6 +51,8 @@ module Monads
       case other
       when Just(T)
         value! <=> other.value!
+      else
+        1
       end
     end
 
@@ -86,8 +88,12 @@ module Monads
       "#{typeof(self)}"
     end
 
-    def <=>(other : Maybe(T))
-      typeof(self) == typeof(other) ? 0 : nil
+    def <=>(other : Nothing)
+      0
+    end
+
+    def <=>(other : Just)
+      -1
     end
 
     def bind(&block : T -> Maybe(U)) : Maybe(U) forall U


### PR DESCRIPTION
Comparable with `nil` values cause compilation errors.

This change behaviors to :
- Right > Left
- Just > Nothing

