### PR TITLE
add `ameba`(linter) to development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ language: crystal
 before_install:
   - shards install
 
-script: crystal spec
+script:
+  - crystal spec
+  - bin/ameba

--- a/shard.yml
+++ b/shard.yml
@@ -7,3 +7,8 @@ authors:
 crystal: 0.26.1
 
 license: MIT
+
+development_dependencies:
+  ameba:
+    github: veelenga/ameba
+    version: ~> 0.9.1

--- a/src/monads/functor.cr
+++ b/src/monads/functor.cr
@@ -3,4 +3,3 @@ module Monads
     abstract def fmap(&block : T -> U) : Functor(U)
   end
 end
-

--- a/src/monads/monad.cr
+++ b/src/monads/monad.cr
@@ -11,4 +11,3 @@ module Monads
     abstract def bind(&block : T -> Monad(U)) : Monad(U) forall U
   end
 end
-


### PR DESCRIPTION
[Ameba](https://github.com/veelenga/ameba) is linter tool for Crystal.
I add `ameba` package dependency to this project, and add `bin/ameba` to `.travis.yaml` to run ameba in CI.