### PR TITLE
change block to Proc

### DIFF
--- a/spec/monads/either/left_sepc.cr
+++ b/spec/monads/either/left_sepc.cr
@@ -60,16 +60,11 @@ describe Monads::Left do
       monad = Monads::Left.new(1)
       monad.value_or(5).should eq(5)
     end
-
-    it "export value (block)" do
-      monad = Monads::Left.new(1)
-      monad.value_or { 5 }.should eq(5)
-    end
   end
 
   describe "#fmap" do
     it "not increase by one" do
-      monad = Monads::Left.new(1).fmap { |value| value + 1 }
+      monad = Monads::Left.new(1).fmap(->(value : String) { value + "a" })
       monad.should eq(Monads::Left.new(1))
     end
   end
@@ -178,7 +173,7 @@ describe Monads::Left do
 
   describe "#bind" do
     it "#bind return self" do
-      monad = Monads::Left.new(1).bind {|x| Monads::Right.new(x.to_s)}
+      monad = Monads::Left.new(1).bind(->(x : Int32) { Monads::Right.new(x.to_s) })
       monad.should eq(Monads::Left.new(1))
     end
   end

--- a/spec/monads/either/right_spec.cr
+++ b/spec/monads/either/right_spec.cr
@@ -61,16 +61,11 @@ describe Monads::Right do
       monad = Monads::Right.new(1)
       monad.value_or(5).should eq(1)
     end
-
-    it "export value (block)" do
-      monad = Monads::Right.new(1)
-      monad.value_or { 5 }.should eq(1)
-    end
   end
 
   describe "#fmap" do
     it "increase by one" do
-      monad = Monads::Right.new(1).fmap { |value| value + 1 }
+      monad = Monads::Right.new(1).fmap(->(value : Int32) { value + 1 })
       monad.should eq(Monads::Right.new(2))
     end
   end
@@ -179,7 +174,7 @@ describe Monads::Right do
 
   describe "#bind" do
     it "#bind apply block" do
-      monad = Monads::Right.new(1).bind {|x| Monads::Right.new(x.to_s)}
+      monad = Monads::Right.new(1).bind(->(x : Int32) { Monads::Right.new(x.to_s) })
       monad.should eq(Monads::Right.new("1"))
     end
   end

--- a/spec/monads/maybe/just_spec.cr
+++ b/spec/monads/maybe/just_spec.cr
@@ -39,11 +39,6 @@ describe Monads::Just do
       monad = Monads::Just.new(1)
       monad.value_or(5).should eq(1)
     end
-
-    it "export value (block)" do
-      monad = Monads::Just.new(1)
-      monad.value_or { 5 }.should eq(1)
-    end
   end
 
   describe "#or" do
@@ -55,27 +50,22 @@ describe Monads::Just do
   end
 
   describe "#bind" do
-    it "export value (block)" do
-      monad = Monads::Just.new(1)
-      monad.bind { |value| Monads::Just.new(value + 1) }.should eq(Monads::Just.new(2))
-    end
-
     it "export value (proc)" do
-      monad = Monads::Just.new(1)
-      monad.bind(&->(value : Int32){ Monads::Just.new(value + 1) }).should eq(Monads::Just.new(2))
+      monad = Monads::Just.new(1).bind(->(value : Int32) { Monads::Just.new(value + 1) })
+      monad.should eq(Monads::Just.new(2))
     end
   end
 
   describe "#fmap" do
     it "increase by one" do
-      monad = Monads::Just.new(1).fmap { |value| value + 1 }
+      monad = Monads::Just.new(1).fmap(->(value : Int32) { value + 1 })
       monad.should eq(Monads::Just.new(2))
     end
   end
 
   describe "#map_or" do
     it "apply function in the case of Just" do
-      monad = Monads::Just.new(2).map_or(-1) { |value| value + 1 }
+      monad = Monads::Just.new(2).map_or(-1, ->(value : Int32) { value + 1 })
       monad.should eq(3)
     end
   end

--- a/spec/monads/maybe/nothing_spec.cr
+++ b/spec/monads/maybe/nothing_spec.cr
@@ -32,11 +32,6 @@ describe Monads::Nothing do
       monad = Monads::Nothing(Int32).new
       monad.value_or(5).should eq(5)
     end
-
-    it "export value (block)" do
-      monad = Monads::Nothing(Int32).new
-      monad.value_or { 5 }.should eq(5)
-    end
   end
 
   describe "#or" do
@@ -48,27 +43,22 @@ describe Monads::Nothing do
   end
 
   describe "#bind" do
-    it "export value (block)" do
-      monad = Monads::Nothing(Int32).new
-      monad.bind { |value| Monads::Maybe.return(value + 1) }.should eq(monad)
-    end
-
     it "export value (proc)" do
-      monad = Monads::Nothing(Int32).new
-      monad.bind(&->(value : Int32){ Monads::Maybe.return(value + 1) }).should eq(monad)
+      monad = Monads::Nothing(Int32).new.bind(->(value : Int32) { Monads::Maybe.return(value + 1) })
+      monad.should eq(monad)
     end
   end
 
   describe "#fmap" do
     it "not increase by one" do
-      monad = Monads::Nothing(String).new.fmap { |value| value + "added" }
+      monad = Monads::Nothing(String).new.fmap(->(value : Int32) { value + 1 })
       monad.should eq(Monads::Nothing(String).new)
     end
   end
 
   describe "#map_or" do
     it "return default value in the case of Nothign" do
-      monad = Monads::Nothing(Int32).new.map_or(-1) { |value| value + 1 }
+      monad = Monads::Nothing(Int32).new.map_or(-1, ->(value : Int32) { value + 1 })
       monad.should eq(-1)
     end
   end

--- a/src/monads/either.cr
+++ b/src/monads/either.cr
@@ -4,7 +4,7 @@ module Monads
   abstract struct Either(E, T) < Monad(T)
     include Comparable(Either)
 
-    def value!
+    def value! : E | T
       @data
     end
 
@@ -24,24 +24,22 @@ module Monads
       io << to_s
     end
 
-    def self.return(value : T)
+    def self.return(value : T) : Right(T)
       Right.new(value)
     end
 
-    abstract def value_or(element)
-    abstract def value_or(&block : -> U) forall U
+    abstract def value_or(element : U) : T | U forall U
     abstract def or(monad : Either)
     abstract def <=>(other : Right)
     abstract def <=>(other : Left)
   end
 
   struct Right(T) < Either(Nil, T)
-
     def initialize(@data : T)
     end
 
-    def fmap(&block : T -> U) : Either forall U
-      Right.new(block.call(@data))
+    def fmap(lambda : T -> U) : Right(U) forall U
+      Right.new(lambda.call(@data))
     end
 
     def <=>(other : Right)
@@ -52,11 +50,7 @@ module Monads
       1
     end
 
-    def value_or(element)
-      value!
-    end
-
-    def value_or(&block : -> U) : U | T forall U
+    def value_or(element : _)
       value!
     end
 
@@ -64,8 +58,8 @@ module Monads
       self
     end
 
-    def bind(&block : T -> Either(E, U)) forall E, U
-      block.call(self.value!)
+    def bind(lambda : T -> Either(E, U)) forall E, U
+      lambda.call(self.value!)
     end
   end
 
@@ -73,7 +67,7 @@ module Monads
     def initialize(@data : E)
     end
 
-    def fmap(&block : E -> U) : Either forall U
+    def fmap(lambda : _ -> _) : Left(E)
       self
     end
 
@@ -85,19 +79,15 @@ module Monads
       -1
     end
 
-    def value_or(element)
+    def value_or(element : U) forall U
       element
-    end
-
-    def value_or(&block : -> U) : U | E forall U
-      block.call
     end
 
     def or(monad : Either)
       monad
     end
 
-    def bind(&block : T -> Either(F, U)) forall T, U, F
+    def bind(lambda : _ -> _) : Left(E)
       self
     end
   end

--- a/src/monads/functor.cr
+++ b/src/monads/functor.cr
@@ -1,5 +1,5 @@
 module Monads
   abstract struct Functor(T)
-    abstract def fmap(&block : T -> U) : Functor(U)
+    abstract def fmap(lambda : T -> U) : Functor(U)
   end
 end

--- a/src/monads/maybe.cr
+++ b/src/monads/maybe.cr
@@ -12,7 +12,7 @@ module Monads
       !just?
     end
 
-    def self.return(v : T)
+    def self.return(v : T) : Just(T)
       Just.new(v)
     end
 
@@ -23,14 +23,12 @@ module Monads
     abstract def <=>(other : Nothing)
     abstract def <=>(other : Just)
     abstract def to_s
-    abstract def or(default : Maybe(T)) : Maybe(T)
-    abstract def value_or(default : T) : T
-    abstract def value_or(&block : -> T) : T
-    abstract def map_or(default : U, &block : T -> U) : U forall U
+    abstract def or(default : Maybe) : Maybe
+    abstract def value_or(default : U) : T | U forall U
+    abstract def map_or(default : U, lambda : T -> U) : U forall U
   end
 
   struct Just(T) < Maybe(T)
-
     def initialize(@data : T)
     end
 
@@ -38,8 +36,8 @@ module Monads
       @data
     end
 
-    def fmap(&block : T -> U) : Just(U) forall U
-      Just(U).new(block.call(@data))
+    def fmap(lambda : T -> U) : Just(U) forall U
+      Just.new(lambda.call(@data))
     end
 
     def to_s
@@ -54,30 +52,25 @@ module Monads
       1
     end
 
-    def bind(&block : T -> Maybe(U)) : Maybe(U) forall U
-      block.call(value!)
+    def bind(lambda : T -> Just(U)) : Just(U) forall U
+      lambda.call(value!)
     end
 
-    def value_or(default : T) : T
+    def value_or(default : _)
       value!
     end
 
-    def value_or(&block : -> T) : T
-      value!
-    end
-
-    def or(default : Maybe(T)) : Maybe(T)
+    def or(default : Maybe)
       Just.new(value!)
     end
 
-    def map_or(default : U, &block : T -> U) : U forall U
-      block.call(value!)
+    def map_or(default : U, lambda : T -> U) forall U
+      lambda.call(value!)
     end
   end
 
   struct Nothing(T) < Maybe(T)
-
-    def fmap(&block : T -> U) : Nothing(U) forall U
+    def fmap(lambda : _ -> U) : Nothing forall U
       Nothing(U).new
     end
 
@@ -93,23 +86,20 @@ module Monads
       -1
     end
 
-    def bind(&block : T -> Maybe(U)) : Maybe(U) forall U
+    def bind(lambda : _ -> U) : Nothing forall U
       Nothing(U).new
     end
 
-    def value_or(default : T) : T
+    def value_or(default : U) forall U
+      print(default)
       default
     end
 
-    def value_or(&block : -> T) : T
-      block.call
-    end
-
-    def or(default : Maybe(T)) : Maybe(T)
+    def or(default : Maybe)
       default
     end
 
-    def map_or(default : U, &block : T -> U) : U forall U
+    def map_or(default : U, lambda : _ -> _) forall U
       default
     end
   end

--- a/src/monads/monad.cr
+++ b/src/monads/monad.cr
@@ -7,6 +7,6 @@ module Monads
       raise NotImplementedError.new("implement `#{Monad(T)}::return` method")
     end
 
-    abstract def bind(&block : T -> Monad(U)) : Monad(U) forall U
+    abstract def bind(lambda : T -> Monad(U)) : Monad(U) forall U
   end
 end


### PR DESCRIPTION
# Contents of change
Changed following methods which received `&block` to receive `Proc`.

* `value_or`
* `fmap`
* `bind`
* `map_or`

# Reason
In the current code, following code can not run correctly:
```crystal
Left.new(1).fmap {|x| x + 1}
```
The cause lies with Crystal compiler can't infer function type(compiler can't infer `T` of `&block : T -> U`).
So instead of receiving a `&block`, change it to receive a `Proc`.
As a result, `value_or(&block : ->U)` was deleted because it became impossible to overload.