### PR TITLE
Value or proc

### DIFF
--- a/spec/monads/either/left_sepc.cr
+++ b/spec/monads/either/left_sepc.cr
@@ -169,6 +169,11 @@ describe Monads::Left do
       monad = Monads::Left.new(1).or(Monads::Right.new('a'))
       monad.should eq(Monads::Right.new('a'))
     end
+
+    it "#or return argument with block" do
+      monad = Monads::Left.new(1).or(->(_value : Int32) { Monads::Right.new('a') })
+      monad.should eq(Monads::Right.new('a'))
+    end
   end
 
   describe "#bind" do

--- a/spec/monads/either/left_sepc.cr
+++ b/spec/monads/either/left_sepc.cr
@@ -60,6 +60,11 @@ describe Monads::Left do
       monad = Monads::Left.new(1)
       monad.value_or(5).should eq(5)
     end
+
+    it "export value (unit)" do
+      monad = Monads::Left.new(1)
+      monad.value_or(->(x : Int32) { x + 1 }).should eq(2)
+    end
   end
 
   describe "#fmap" do

--- a/spec/monads/either/right_spec.cr
+++ b/spec/monads/either/right_spec.cr
@@ -61,6 +61,11 @@ describe Monads::Right do
       monad = Monads::Right.new(1)
       monad.value_or(5).should eq(1)
     end
+
+    it "export value (unit) with block" do
+      monad = Monads::Right.new(1)
+      monad.value_or(-> { 5 }).should eq(1)
+    end
   end
 
   describe "#fmap" do

--- a/spec/monads/either/right_spec.cr
+++ b/spec/monads/either/right_spec.cr
@@ -170,6 +170,11 @@ describe Monads::Right do
       monad = Monads::Right.new(1).or(Monads::Right.new('a'))
       monad.should eq(Monads::Right.new(1))
     end
+
+    it "#or return self with block" do
+      monad = Monads::Right.new(1).or(->(_value : Int32) { Monads::Right.new('a') })
+      monad.should eq(Monads::Right.new(1))
+    end
   end
 
   describe "#bind" do

--- a/src/monads/either.cr
+++ b/src/monads/either.cr
@@ -59,6 +59,10 @@ module Monads
       self
     end
 
+    def or(lambda : _ -> _) : Right(T)
+      self
+    end
+
     def bind(lambda : T -> Either(E, U)) forall E, U
       lambda.call(self.value!)
     end
@@ -90,6 +94,10 @@ module Monads
 
     def or(monad : Either)
       monad
+    end
+
+    def or(lambda : E -> _)
+      lambda.call(@data)
     end
 
     def bind(lambda : _ -> _) : Left(E)

--- a/src/monads/either.cr
+++ b/src/monads/either.cr
@@ -88,6 +88,10 @@ module Monads
       -1
     end
 
+    def value_or(lambda : E -> _)
+      lambda.call(@data)
+    end
+
     def value_or(element : U) forall U
       element
     end


### PR DESCRIPTION
`Monads::Right` don't need `value_or` overload.