### PR TITLE
Implement #permutations, #subsequences and #join

### DIFF
--- a/spec/monads/list_spec.cr
+++ b/spec/monads/list_spec.cr
@@ -158,7 +158,7 @@ describe Monads::List do
       boolean.should be_truthy
     end
 
-    it "Listp[1].empty? == false" do
+    it "List[1].empty? == false" do
       boolean = Monads::List[1].empty?
       boolean.should be_falsey
     end
@@ -168,6 +168,95 @@ describe Monads::List do
     it "List[1,2,3].last == 3" do
       value = Monads::List[1,2,3].last
       value.should eq(3)
+    end
+  end
+
+  describe "#join" do
+    it "List[1,2,3].join(\",\") == \"1,2,3\"" do
+      value = Monads::List[1,2,3].join(",")
+      value.should eq("1,2,3")
+    end
+
+    it "List[1,2,3].join(',') == \"1,2,3\"" do
+      value = Monads::List[1,2,3].join(',')
+      value.should eq("1,2,3")
+    end
+
+    it "List[1,2,3].join == \"123\"" do
+      value = Monads::List[1,2,3].join
+      value.should eq("123")
+    end
+
+    it "List[].join == \"\"" do
+      value = Monads::List.new([] of Int32).join
+      value.should eq("")
+    end
+
+    it "List[].join(\",\") == \"\"" do
+      value = Monads::List.new([] of Int32).join(",")
+      value.should eq("")
+    end
+
+    it "List[1].join == \"1\"" do
+      value = Monads::List[1].join
+      value.should eq("1")
+    end
+
+    it "List[1].join(\",\") == \"1\"" do
+      value = Monads::List[1].join(",")
+      value.should eq("1")
+    end
+  end
+
+  describe "#subsequences" do
+    it "List[1,2].subsequences == List[List[], List[1], List[2], List[1,2], List[2,1]]" do
+      value = Monads::List[1,2].subsequences
+      value.should eq(Monads::List[
+        Monads::List.new([] of Int32),
+        Monads::List[1],
+        Monads::List[2],
+        Monads::List[1,2],
+        Monads::List[2,1]
+      ])
+    end
+
+    it "List[].subsequences == List[List[]]" do
+      value = Monads::List.new([] of Int32).subsequences
+      value.should eq(Monads::List[
+        Monads::List.new([] of Int32)
+      ])
+    end
+
+    it "List[1].subsequences == List[List[], List[1]]" do
+      value = Monads::List[1].subsequences
+      value.should eq(Monads::List[
+        Monads::List.new([] of Int32),
+        Monads::List[1]
+      ])
+    end
+  end
+
+  describe "#permutations" do
+    it "List[].permutations == List[List[]]" do
+      value = Monads::List.new([] of Int32).permutations
+      value.should eq(Monads::List[
+        Monads::List.new([] of Int32)
+      ])
+    end
+
+    it "List[1].permutations == List[List[1]]" do
+      value = Monads::List[1].permutations
+      value.should eq(Monads::List[
+        Monads::List[1]
+      ])
+    end
+
+    it "List[1, 2].permutations == List[List[1,2], List[2,1]]" do
+      value = Monads::List[1,2].permutations
+      value.should eq(Monads::List[
+        Monads::List[1,2],
+        Monads::List[2,1]
+      ])
     end
   end
 end

--- a/src/monads/list.cr
+++ b/src/monads/list.cr
@@ -1,5 +1,6 @@
 require "./maybe"
 require "./monad"
+require "big"
 
 module Monads
   struct List(T) < Monad(T)
@@ -41,6 +42,28 @@ module Monads
 
     def empty?
       @value.size == 0
+    end
+
+    def join(sep = "")
+      @value.join(sep)
+    end
+
+    def subsequences
+      List.new(
+        (1..size).reduce([List.new([] of T)]) { |acc, i|
+          acc + @value.permutations(i).map { |x|
+            List.new(x)
+          }
+        }
+      )
+    end
+
+    def permutations
+      List.new(
+        @value.permutations.map { |x|
+          List.new(x)
+        }
+      )
     end
 
     def last


### PR DESCRIPTION
# Abstract
add following methods to `List`

* `#permutations`: return possible permutations of `List`
* `#subsequences`: return all subsequences of `List`
* `#join`: combine contents of `List`. However, `sep` is inserted between contents

# Example
## `#permutations`
```crystal
List[1,2,3].permutations == List[
  List[1,2,3],
  List[1,3,2],
  List[2,1,3],
  List[2,3,1],
  List[3,1,2],
  List[3,2,1]
]

# empty list #subseqences return List that has empty List
List[].subsequences == List[List[]]
```

## `#subsequences`
```crystal
List[1,2].subsequences == List[
  List[],
  List[1],
  List[2],
  List[1,2],
  List[2,1]
]

# empty list #subsequences return List that has empty List
List[].subsequences == List[List[]]
```

## `#join`
```crystal
List[1,2].join(", ") == "1, 2"
# It is also valid without arguments
List[1,2].join == "12"

# empty list #join return empty string
List[].join == ""
List[].join(", ") == ""
```