### PR TITLE
Add #sort to List

### DIFF
--- a/spec/monads/list_spec.cr
+++ b/spec/monads/list_spec.cr
@@ -297,4 +297,40 @@ describe Monads::List do
       stop.should eq(Iterator::Stop::INSTANCE)
     end
   end
+
+  describe "#sort" do
+    describe "unit" do
+      it "List[].sort == List[]" do
+        value = Monads::List.new([] of Int32).sort
+        value.should eq(Monads::List.new([] of Int32))
+      end
+
+      it "List[1].sort == List[]" do
+        value = Monads::List[1].sort
+        value.should eq(Monads::List[1])
+      end
+
+      it "List[1,3,2].sort == List[]" do
+        value = Monads::List[1,3,2].sort
+        value.should eq(Monads::List[1,2,3])
+      end
+    end
+
+    describe "block" do
+      it "List[].sort { |x, y| x <=> y } == List[]" do
+        value = Monads::List.new([] of Int32).sort { |x, y| x <=> y }
+        value.should eq(Monads::List.new([] of Int32))
+      end
+
+      it "List[1].sort { |x, y| x <=> y } == List[1]" do
+        value = Monads::List[1].sort { |x, y| x <=> y }
+        value.should eq(Monads::List[1])
+      end
+
+      it "List[1,3,2].sort { |x, y| x <=> y } == List[1,2,3]" do
+        value = Monads::List[1,3,2].sort { |x, y| x <=> y }
+        value.should eq(Monads::List[1,2,3])
+      end
+    end
+  end
 end

--- a/src/monads/list.cr
+++ b/src/monads/list.cr
@@ -109,5 +109,13 @@ module Monads
     def reverse : List(T)
       List.new(@value.reverse)
     end
+
+    def sort : List(T)
+      List.new(@value.sort)
+    end
+
+    def sort(&block : T, T -> U) : List(T) forall U
+      List.new(@value.sort(&block))
+    end
   end
 end


### PR DESCRIPTION
# Abstract
add `#sort` to `List`.
This method returns sorted new `List`.

# Example
```crystal
List[].sort == List[]
List[1,4,2,3].sort == List[1,2,3,4]
# able to pass block
(List[1,3,2].sort { |x, y| x <=> y }) == List[1,2,3]
# sort by descending order
(List[1,3,2].sort { |x, y| y <=> x }) == List[1,2,3]
```