### PR TITLE
Add `#|` (bind) and `#>>` (sequence) operator, and fixed Maybe#bind's return type

### DIFF
--- a/spec/monads/monad_spec.cr
+++ b/spec/monads/monad_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+describe Monads::Monad do
+  describe "#|" do
+    it "Just(1) | ->(x : Int32) { Just(x.to_s) } == Just(\"1\")" do
+      value = Monads::Maybe.return(1) \
+        | ->(x : Int32) { Monads::Maybe.return(x.to_s) }
+      value.should eq(Monads::Maybe.return("1"))
+    end
+
+    it "Left(1) | ->(x : String) { Right(x.to_i) } == Left(1)" do
+      value = Monads::Left.new(1) \
+        | ->(x : String) { Monads::Either.return(x.to_i) }
+      value.should eq(Monads::Left.new(1))
+    end
+  end
+
+  describe "#>>" do
+    it "List[1,2,3] >> List[] == List[]" do
+      value = Monads::List[1,2,3] >> Monads::List.new([] of Int32)
+      value.should eq(Monads::List.new([] of Int32))
+    end
+
+    it "Nothing >> Just(1) == Just(1)" do
+      value = Monads::Nothing(Int32).new >> Monads::Maybe.return(1)
+      value.should eq(Monads::Maybe.return(1))
+    end
+  end
+end

--- a/src/monads.cr
+++ b/src/monads.cr
@@ -1,6 +1,4 @@
-require "./monads/either"
-require "./monads/maybe"
-require "./monads/list"
+require "./monads/*"
 
 module Monads
   # Requirements for 1.0.0

--- a/src/monads/maybe.cr
+++ b/src/monads/maybe.cr
@@ -52,7 +52,7 @@ module Monads
       1
     end
 
-    def bind(lambda : T -> Just(U)) : Just(U) forall U
+    def bind(lambda : T -> Maybe(_)) : Maybe
       lambda.call(value!)
     end
 
@@ -90,7 +90,7 @@ module Monads
       -1
     end
 
-    def bind(lambda : _ -> U) : Nothing forall U
+    def bind(lambda : _ -> Maybe(U)) : Maybe forall U
       Nothing(U).new
     end
 

--- a/src/monads/monad.cr
+++ b/src/monads/monad.cr
@@ -8,5 +8,13 @@ module Monads
     end
 
     abstract def bind(lambda : T -> Monad(U)) : Monad(U) forall U
+
+    def |(other : _ -> Monad(U)) forall U
+      self.bind(other)
+    end
+
+    def >>(other : Monad(U)) forall U
+      other
+    end
   end
 end


### PR DESCRIPTION
# Abstract
add `#|` - bind operator - and `#>>` - squence operator -.

* `#|`: same as `Monads#bind(lambda : _ -> Monad(U)) forall U`
* `#>>`: discards left hand side `Monad` and return right hand side `Monad`

and fix `Maybe#bind`, which return **wrong** result.
For example, `Maybe#bind` required to return `Just` type, but return type should be originally `Maybe` (function which is passed to `Maybe#bind` may return `Just` or `Nothing`).

# Example
## `#|`
```crystal
Just.new(1) \
  | ->(x : Int32) { Just.new(x.to_s) \
  | ->(x : String) { Just.new((x + "12").to_i) } \
  == Just.new(112)

Just.new(1) \
  | ->(x : Int32) { Nothing(String).new } \
  | ->(x : String) { Just.new((x + "12").to_i) } \
  == Nothing(Int32).new
```
## `#>>`
```crystal
List[1,2,3] >> List['a', 'b'] == List['a', 'b']
Nothing(Int32).new >> Just.new(1) >> Just("a") == Just("a")
```