### PR TITLE
Fix Maybe value_or block variant

### DIFF
--- a/spec/monads/maybe/just_spec.cr
+++ b/spec/monads/maybe/just_spec.cr
@@ -39,6 +39,11 @@ describe Monads::Just do
       monad = Monads::Just.new(1)
       monad.value_or(5).should eq(1)
     end
+
+    it "export value (block)" do
+      monad = Monads::Just.new(1)
+      monad.value_or { 5 }.should eq(1)
+    end
   end
 
   describe "#or" do

--- a/spec/monads/maybe/nothing_spec.cr
+++ b/spec/monads/maybe/nothing_spec.cr
@@ -32,6 +32,11 @@ describe Monads::Nothing do
       monad = Monads::Nothing(Int32).new
       monad.value_or(5).should eq(5)
     end
+
+    it "export value (block)" do
+      monad = Monads::Nothing(Int32).new
+      monad.value_or { 6 }.should eq(6)
+    end
   end
 
   describe "#or" do

--- a/src/monads/maybe.cr
+++ b/src/monads/maybe.cr
@@ -25,6 +25,7 @@ module Monads
     abstract def to_s
     abstract def or(other : Maybe)
     abstract def or(other : -> _)
+    abstract def value_or(other : -> U) forall U
     abstract def value_or(other : U) forall U
     abstract def map_or(default : U, lambda : T -> U) forall U
 
@@ -41,7 +42,7 @@ module Monads
       map_or(default, block)
     end
 
-    def value_or(&block : E -> U) forall U
+    def value_or(&block : -> U) forall U
       value_or(block)
     end
 
@@ -80,6 +81,10 @@ module Monads
 
     def bind(lambda : T -> Maybe(_))
       lambda.call(value!)
+    end
+
+    def value_or(other : -> _)
+      value!
     end
 
     def value_or(other : _)
@@ -126,6 +131,10 @@ module Monads
 
     def bind(lambda : _ -> Maybe(U)) forall U
       Nothing(U).new
+    end
+
+    def value_or(other : -> U) forall U
+      other.call
     end
 
     def value_or(other : U) forall U


### PR DESCRIPTION
## Summary
- support passing a block to `Maybe#value_or`
- test value_or blocks for `Just` and `Nothing`

## Testing
- `crystal spec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684003f834f0832f8b2ddb316fa2fb38