### PR TITLE
Fix spec description for sorting a single-item list

### DIFF
--- a/spec/monads/list_spec.cr
+++ b/spec/monads/list_spec.cr
@@ -305,7 +305,7 @@ describe Monads::List do
         value.should eq(Monads::List.new([] of Int32))
       end
 
-      it "List[1].sort == List[]" do
+      it "List[1].sort == List[1]" do
         value = Monads::List[1].sort
         value.should eq(Monads::List[1])
       end


### PR DESCRIPTION
## Summary
- fix description for `List[1].sort`

## Testing
- `crystal spec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840059373f0832f9eb3f6ea6691e39d