### PR TITLE
Fix invalid Left >= spec expectation

### DIFF
--- a/spec/monads/either/left_spec.cr
+++ b/spec/monads/either/left_spec.cr
@@ -162,8 +162,8 @@ describe Monads::Left do
     end
 
     it "'Left(2) >= Left(1)' should be invalid" do
-      boolean = Monads::Left.new(1) >= Monads::Left.new(1)
-      boolean.should be_truthy
+      boolean = Monads::Left.new(2) >= Monads::Left.new(1)
+      boolean.should be_falsey
     end
 
     it "comparing different type by '#>=' should be invalid" do


### PR DESCRIPTION
## Summary
- correct the `Left >= Left` comparison test

## Testing
- `crystal spec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005a614fc832fbaef9f04a6f5fdef