### PR TITLE
Release 1.2.3 + Crystal 1.20.2 CI, fix red nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - 1.17.0
           - 1.18.0
           - 1.19.0
+          - 1.20.2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +40,7 @@ jobs:
           - 1.17.0
           - 1.18.0
           - 1.19.0
+          - 1.20.2
         experimental:
           - false
         include:
@@ -51,7 +53,11 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal_version }}
+      # Skip development dependencies (ameba): the linter is only needed by the
+      # check_format job, and its postinstall build does not compile against
+      # Crystal nightly. Installing it here would make the specs job fail for a
+      # reason unrelated to the library under test.
       - name: Install shards
-        run: shards install --ignore-crystal-version
+        run: shards install --ignore-crystal-version --without-development
       - name: Run tests
         run: crystal spec

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.19.0
+crystal 1.20.2

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: monads
-version: 1.2.2
+version: 1.2.3
 
 authors:
   - Alexandre Lairan <alexandrelairan+github@gmail.com>

--- a/spec/monads_spec.cr
+++ b/spec/monads_spec.cr
@@ -3,6 +3,6 @@ require "./monads/**"
 
 describe Monads do
   it "should have version" do
-    Monads::VERSION.should eq("1.2.2")
+    Monads::VERSION.should eq("1.2.3")
   end
 end

--- a/src/monads.cr
+++ b/src/monads.cr
@@ -1,5 +1,5 @@
 require "./monads/*"
 
 module Monads
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
## Why nightly was red

The `specs (nightly, true)` job was failing in the **Install shards** step, not in the tests — and it was **not** caused by #67 (whose specs pass on all stable Crystals and locally, 260 examples / 0 failures).

`shards install` builds the `ameba` dev-dependency via its postinstall hook, and `ameba` 1.6.4 (latest) does not compile against Crystal **nightly**:

```
In src/ameba/tokenizer.cr:88:15
Error: undefined method 'next_string_array_token' for Crystal::Lexer
```

Crystal nightly changed a compiler-internal lexer API that ameba relies on. Since that matrix entry has `continue-on-error: true`, the overall run still reported green, which is why the merge looked clean.

## Changes

- **Bump version to 1.2.3** — `shard.yml`, `src/monads.cr`, `spec/monads_spec.cr`.
- **Add Crystal 1.20.2** (latest stable) to both the `check_format` and `specs` matrices.
- **Fix the red nightly**: the `specs` job now installs with `--without-development`, so it no longer builds the `ameba` linter (which the specs job never uses). Nightly now actually tests the library against the bleeding-edge compiler instead of failing on an unrelated linter build. The linter still runs in `check_format` on stable Crystals.

## Verification

- `crystal spec` → 260 examples, 0 failures, 0 errors
- `crystal tool format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)